### PR TITLE
[Feature]: 兼容阿里云百炼生图接口格式

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# 统一仓库行尾为 LF，避免 Windows autocrlf 把工作区文本转成 CRLF
+# 破坏 vendor 字节级完整性校验（scripts/package-extension.mjs validateLumnoRuntime 等）
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ refs/
 /scripts/safari-alpha-vfx.mjs
 /safari/Card Master/Card Master/Assets.xcassets/AppIcon.appiconset/*.png
 /safari/Card Master/Card Master/Resources/Icon.png
+.pnpm-store/

--- a/src/ai/domain/ai-services-schema.ts
+++ b/src/ai/domain/ai-services-schema.ts
@@ -2,6 +2,7 @@ import type {
   AiServicesConfig,
   ImageServiceConfig,
   ImageServiceConfigInput,
+  ImageServiceProtocol,
   ModelServiceConfig,
   SpeechServiceConfig,
   SpeechServiceConfigInput,
@@ -28,6 +29,10 @@ const AI_SERVICES_KEYS = new Set([
   'modelService',
   'imageService',
   'speechService',
+]);
+const IMAGE_SERVICE_PROTOCOLS = new Set<ImageServiceProtocol>([
+  'openai-images',
+  'dashscope',
 ]);
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -125,7 +130,7 @@ export function normalizeImageServiceInput(
   if (
     (value.credentialSource !== 'model-service' &&
       value.credentialSource !== 'independent') ||
-    value.protocol !== 'openai-images' ||
+    !IMAGE_SERVICE_PROTOCOLS.has(value.protocol as ImageServiceProtocol) ||
     typeof value.baseUrl !== 'string' ||
     value.baseUrl.length > 2_048 ||
     !isSecureServiceUrl(value.baseUrl) ||
@@ -139,10 +144,14 @@ export function normalizeImageServiceInput(
   ) {
     return null;
   }
+  const protocol = value.protocol as ImageServiceProtocol;
   return {
     credentialSource: value.credentialSource,
-    protocol: value.protocol,
-    baseUrl: normalizeAiServiceBaseUrl(value.baseUrl, '/v1'),
+    protocol,
+    baseUrl: normalizeAiServiceBaseUrl(
+      value.baseUrl,
+      protocol === 'openai-images' ? '/v1' : '',
+    ),
     model: value.model.trim(),
     ...(typeof value.apiKey === 'string'
       ? { apiKey: value.apiKey.trim() }

--- a/src/ai/domain/assistant-readiness.ts
+++ b/src/ai/domain/assistant-readiness.ts
@@ -87,7 +87,7 @@ export function assistantReadinessIssues({
     ) {
       issues.push({
         id: 'image-api-key',
-        title: 'OpenAI 兼容图像服务 API 密钥尚未配置',
+        title: '图像服务 API 密钥尚未配置',
         detail: '无法生成或更新脚本卡牌封面。',
       });
     }

--- a/src/ai/domain/image-generation-protocol.ts
+++ b/src/ai/domain/image-generation-protocol.ts
@@ -1,0 +1,24 @@
+import type { ImageServiceProtocol } from './types';
+
+export interface ImageGenerationRequestInput {
+  prompt: string;
+  model: string;
+  /** 统一 '宽x高'（小写 x 分隔），各适配器按需转换 */
+  size: string;
+  count?: number;
+  quality?: string;
+  outputFormat?: string;
+}
+
+export interface ImageGenerationProtocolAdapter {
+  readonly protocol: ImageServiceProtocol;
+  readonly label: string;
+  readonly description: string;
+  readonly defaultBaseUrl: string;
+  /** 拼接该协议的完整请求 URL */
+  buildUrl(baseUrl: string): string;
+  /** 构建该协议请求体 */
+  buildRequestBody(input: ImageGenerationRequestInput): Record<string, unknown>;
+  /** 解析响应，统一产出 { url } 或 { b64 }（至少一个），解析失败返回 null */
+  parseResponse(payload: unknown): { url?: string; b64?: string } | null;
+}

--- a/src/ai/domain/image-generation-protocol.ts
+++ b/src/ai/domain/image-generation-protocol.ts
@@ -10,15 +10,23 @@ export interface ImageGenerationRequestInput {
   outputFormat?: string;
 }
 
+export type ImageGenerationResult = {
+  url?: string;
+  b64?: string;
+  width?: number;
+  height?: number;
+};
+
 export interface ImageGenerationProtocolAdapter {
   readonly protocol: ImageServiceProtocol;
   readonly label: string;
   readonly description: string;
   readonly defaultBaseUrl: string;
+  readonly defaultModel: string;
   /** 拼接该协议的完整请求 URL */
   buildUrl(baseUrl: string): string;
   /** 构建该协议请求体 */
   buildRequestBody(input: ImageGenerationRequestInput): Record<string, unknown>;
   /** 解析响应，统一产出 { url } 或 { b64 }（至少一个），解析失败返回 null */
-  parseResponse(payload: unknown): { url?: string; b64?: string } | null;
+  parseResponse(payload: unknown): ImageGenerationResult | null;
 }

--- a/src/ai/domain/types.ts
+++ b/src/ai/domain/types.ts
@@ -43,7 +43,7 @@ export type ModelServiceConfigInput = Omit<ModelServiceConfig, 'apiKey'> & {
 };
 
 export type ImageServiceCredentialSource = 'model-service' | 'independent';
-export type ImageServiceProtocol = 'openai-images';
+export type ImageServiceProtocol = 'openai-images' | 'dashscope';
 
 export type ImageServiceConfig = {
   credentialSource: ImageServiceCredentialSource;

--- a/src/ai/infrastructure/ai-service-http.ts
+++ b/src/ai/infrastructure/ai-service-http.ts
@@ -6,7 +6,7 @@ export type AiServiceFetch = (
 ) => Promise<Response>;
 
 export type AiServiceRequestContext = {
-  protocol?: 'responses' | 'chat-completions' | 'openai-images';
+  protocol?: 'responses' | 'chat-completions' | 'openai-images' | 'dashscope';
 };
 
 export type AiServiceRequestDiagnostic = {

--- a/src/ai/infrastructure/dashscope-images-adapter.test.ts
+++ b/src/ai/infrastructure/dashscope-images-adapter.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { dashscopeImagesAdapter } from './dashscope-images-adapter';
+
+describe('dashscopeImagesAdapter', () => {
+  it('has correct protocol metadata', () => {
+    expect(dashscopeImagesAdapter.protocol).toBe('dashscope');
+    expect(dashscopeImagesAdapter.label).toBe('阿里云百炼（DashScope）');
+    expect(dashscopeImagesAdapter.defaultBaseUrl).toBe(
+      'https://dashscope.aliyuncs.com',
+    );
+  });
+
+  it('buildUrl appends the multimodal-generation path', () => {
+    expect(
+      dashscopeImagesAdapter.buildUrl('https://dashscope.aliyuncs.com'),
+    ).toBe(
+      'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
+    );
+    expect(dashscopeImagesAdapter.buildUrl('https://custom.example')).toBe(
+      'https://custom.example/api/v1/services/aigc/multimodal-generation/generation',
+    );
+  });
+
+  it('buildRequestBody uses star separator in size and wraps prompt in messages', () => {
+    const body = dashscopeImagesAdapter.buildRequestBody({
+      prompt: '一只猫',
+      model: 'z-image-turbo',
+      size: '1024x768',
+      count: 2,
+      quality: 'high',
+      outputFormat: 'webp',
+    });
+    expect(body).toEqual({
+      model: 'z-image-turbo',
+      input: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: '一只猫' }],
+          },
+        ],
+      },
+      parameters: {
+        size: '1024*768',
+        prompt_extend: false,
+      },
+    });
+    // dashscope ignores count/quality/outputFormat
+    expect(body).not.toHaveProperty('n');
+    expect(body).not.toHaveProperty('quality');
+    expect(body).not.toHaveProperty('output_format');
+  });
+
+  it('parseResponse extracts image URL from output.choices[0].message.content', () => {
+    const result = dashscopeImagesAdapter.parseResponse({
+      output: {
+        choices: [
+          {
+            finish_reason: 'stop',
+            message: {
+              role: 'assistant',
+              content: [
+                { image: 'https://oss.example/img.png?Expires=123', text: '' },
+              ],
+            },
+          },
+        ],
+      },
+      usage: { width: 1024, height: 768, image_count: 1 },
+      request_id: 'test-123',
+    });
+    expect(result).toEqual({
+      url: 'https://oss.example/img.png?Expires=123',
+    });
+  });
+
+  it('parseResponse skips non-image content entries', () => {
+    const result = dashscopeImagesAdapter.parseResponse({
+      output: {
+        choices: [
+          {
+            message: {
+              content: [
+                { text: 'description' },
+                { image: 'https://img.test/a.png' },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(result).toEqual({ url: 'https://img.test/a.png' });
+  });
+
+  it('parseResponse returns null for error response format', () => {
+    expect(
+      dashscopeImagesAdapter.parseResponse({
+        code: 'InvalidApiKey',
+        message: 'Invalid API key',
+        request_id: 'err-123',
+      }),
+    ).toBeNull();
+  });
+
+  it('parseResponse returns null for missing output or choices', () => {
+    expect(dashscopeImagesAdapter.parseResponse(null)).toBeNull();
+    expect(dashscopeImagesAdapter.parseResponse({})).toBeNull();
+    expect(dashscopeImagesAdapter.parseResponse({ output: {} })).toBeNull();
+    expect(
+      dashscopeImagesAdapter.parseResponse({ output: { choices: [] } }),
+    ).toBeNull();
+  });
+
+  it('parseResponse returns null when content has no image field', () => {
+    expect(
+      dashscopeImagesAdapter.parseResponse({
+        output: {
+          choices: [{ message: { content: [{ text: 'no image here' }] } }],
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/ai/infrastructure/dashscope-images-adapter.test.ts
+++ b/src/ai/infrastructure/dashscope-images-adapter.test.ts
@@ -9,6 +9,7 @@ describe('dashscopeImagesAdapter', () => {
     expect(dashscopeImagesAdapter.defaultBaseUrl).toBe(
       'https://dashscope.aliyuncs.com',
     );
+    expect(dashscopeImagesAdapter.defaultModel).toBe('qwen-image-3.0');
   });
 
   it('buildUrl appends the multimodal-generation path', () => {
@@ -72,7 +73,30 @@ describe('dashscopeImagesAdapter', () => {
     });
     expect(result).toEqual({
       url: 'https://oss.example/img.png?Expires=123',
+      width: 1024,
+      height: 768,
     });
+  });
+
+  it('scales existing 4K wallpaper sizes into the supported range', () => {
+    const body = dashscopeImagesAdapter.buildRequestBody({
+      prompt: '一片森林',
+      model: 'z-image-turbo',
+      size: '3840x2160',
+    });
+    expect(body).toMatchObject({
+      parameters: { size: '2048*1152' },
+    });
+  });
+
+  it('rejects aspect ratios that cannot keep both sides in range', () => {
+    expect(() =>
+      dashscopeImagesAdapter.buildRequestBody({
+        prompt: '一片森林',
+        model: 'z-image-turbo',
+        size: '4096x512',
+      }),
+    ).toThrow('超出支持范围');
   });
 
   it('parseResponse skips non-image content entries', () => {
@@ -91,6 +115,23 @@ describe('dashscopeImagesAdapter', () => {
       },
     });
     expect(result).toEqual({ url: 'https://img.test/a.png' });
+  });
+
+  it('reads qwen-image 3.0 output dimensions', () => {
+    expect(
+      dashscopeImagesAdapter.parseResponse({
+        output: {
+          choices: [
+            { message: { content: [{ image: 'https://img.test/qwen.png' }] } },
+          ],
+        },
+        usage: { output_width: 1536, output_height: 864 },
+      }),
+    ).toEqual({
+      url: 'https://img.test/qwen.png',
+      width: 1536,
+      height: 864,
+    });
   });
 
   it('parseResponse returns null for error response format', () => {

--- a/src/ai/infrastructure/dashscope-images-adapter.ts
+++ b/src/ai/infrastructure/dashscope-images-adapter.ts
@@ -1,0 +1,62 @@
+import type {
+  ImageGenerationProtocolAdapter,
+  ImageGenerationRequestInput,
+} from '../domain/image-generation-protocol';
+
+export const dashscopeImagesAdapter: ImageGenerationProtocolAdapter = {
+  protocol: 'dashscope',
+  label: '阿里云百炼（DashScope）',
+  description:
+    '使用阿里云百炼 Z-Image 系列多模态生成接口，返回临时图片 URL（24 小时有效）。',
+  defaultBaseUrl: 'https://dashscope.aliyuncs.com',
+
+  buildUrl(baseUrl: string): string {
+    return `${baseUrl}/api/v1/services/aigc/multimodal-generation/generation`;
+  },
+
+  buildRequestBody(
+    input: ImageGenerationRequestInput,
+  ): Record<string, unknown> {
+    return {
+      model: input.model,
+      input: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: input.prompt }],
+          },
+        ],
+      },
+      parameters: {
+        size: input.size.replace('x', '*'),
+        prompt_extend: false,
+      },
+    };
+  },
+
+  parseResponse(payload: unknown): { url?: string; b64?: string } | null {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return null;
+    }
+    const record = payload as Record<string, unknown>;
+    const output = record.output as Record<string, unknown> | undefined;
+    if (!output || typeof output !== 'object') return null;
+    const choices = output.choices;
+    if (!Array.isArray(choices) || choices.length === 0) return null;
+    const firstChoice = choices[0] as Record<string, unknown> | undefined;
+    if (!firstChoice || typeof firstChoice !== 'object') return null;
+    const message = firstChoice.message as Record<string, unknown> | undefined;
+    if (!message || typeof message !== 'object') return null;
+    const content = message.content;
+    if (!Array.isArray(content)) return null;
+    for (const item of content) {
+      if (item && typeof item === 'object' && !Array.isArray(item)) {
+        const entry = item as Record<string, unknown>;
+        if (typeof entry.image === 'string' && entry.image) {
+          return { url: entry.image };
+        }
+      }
+    }
+    return null;
+  },
+};

--- a/src/ai/infrastructure/dashscope-images-adapter.ts
+++ b/src/ai/infrastructure/dashscope-images-adapter.ts
@@ -1,14 +1,44 @@
 import type {
   ImageGenerationProtocolAdapter,
   ImageGenerationRequestInput,
+  ImageGenerationResult,
 } from '../domain/image-generation-protocol';
+
+const MIN_IMAGE_SIDE = 512;
+const MAX_IMAGE_SIDE = 2048;
+const IMAGE_SIDE_STEP = 32;
+
+function dashscopeSize(value: string) {
+  const match = /^(\d+)x(\d+)$/.exec(value);
+  if (!match) throw new Error(`百炼图像尺寸格式无效：${value}`);
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (
+    width >= MIN_IMAGE_SIDE &&
+    width <= MAX_IMAGE_SIDE &&
+    height >= MIN_IMAGE_SIDE &&
+    height <= MAX_IMAGE_SIDE
+  ) {
+    return `${width}*${height}`;
+  }
+  const scale = Math.min(1, MAX_IMAGE_SIDE / width, MAX_IMAGE_SIDE / height);
+  const scaledWidth =
+    Math.floor((width * scale) / IMAGE_SIDE_STEP) * IMAGE_SIDE_STEP;
+  const scaledHeight =
+    Math.floor((height * scale) / IMAGE_SIDE_STEP) * IMAGE_SIDE_STEP;
+  if (scaledWidth < MIN_IMAGE_SIDE || scaledHeight < MIN_IMAGE_SIDE) {
+    throw new Error(`百炼图像尺寸超出支持范围：${value}`);
+  }
+  return `${scaledWidth}*${scaledHeight}`;
+}
 
 export const dashscopeImagesAdapter: ImageGenerationProtocolAdapter = {
   protocol: 'dashscope',
   label: '阿里云百炼（DashScope）',
   description:
-    '使用阿里云百炼 Z-Image 系列多模态生成接口，返回临时图片 URL（24 小时有效）。',
+    '使用阿里云百炼同步图像生成接口，返回临时图片 URL（24 小时有效）。',
   defaultBaseUrl: 'https://dashscope.aliyuncs.com',
+  defaultModel: 'qwen-image-3.0',
 
   buildUrl(baseUrl: string): string {
     return `${baseUrl}/api/v1/services/aigc/multimodal-generation/generation`;
@@ -28,13 +58,13 @@ export const dashscopeImagesAdapter: ImageGenerationProtocolAdapter = {
         ],
       },
       parameters: {
-        size: input.size.replace('x', '*'),
+        size: dashscopeSize(input.size),
         prompt_extend: false,
       },
     };
   },
 
-  parseResponse(payload: unknown): { url?: string; b64?: string } | null {
+  parseResponse(payload: unknown): ImageGenerationResult | null {
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       return null;
     }
@@ -53,7 +83,25 @@ export const dashscopeImagesAdapter: ImageGenerationProtocolAdapter = {
       if (item && typeof item === 'object' && !Array.isArray(item)) {
         const entry = item as Record<string, unknown>;
         if (typeof entry.image === 'string' && entry.image) {
-          return { url: entry.image };
+          const usage = record.usage;
+          const usageRecord =
+            usage && typeof usage === 'object' && !Array.isArray(usage)
+              ? (usage as Record<string, unknown>)
+              : null;
+          const widthValue = usageRecord?.output_width ?? usageRecord?.width;
+          const heightValue = usageRecord?.output_height ?? usageRecord?.height;
+          const width =
+            Number.isSafeInteger(widthValue) && Number(widthValue) > 0
+              ? Number(widthValue)
+              : undefined;
+          const height =
+            Number.isSafeInteger(heightValue) && Number(heightValue) > 0
+              ? Number(heightValue)
+              : undefined;
+          return {
+            url: entry.image,
+            ...(width && height ? { width, height } : {}),
+          };
         }
       }
     }

--- a/src/ai/infrastructure/image-generation-protocol-registry.ts
+++ b/src/ai/infrastructure/image-generation-protocol-registry.ts
@@ -1,0 +1,27 @@
+import type { ImageGenerationProtocolAdapter } from '../domain/image-generation-protocol';
+import type { ImageServiceProtocol } from '../domain/types';
+import { dashscopeImagesAdapter } from './dashscope-images-adapter';
+import { openaiImagesAdapter } from './openai-images-adapter';
+
+export const IMAGE_GENERATION_PROTOCOL_ADAPTERS: readonly ImageGenerationProtocolAdapter[] =
+  [openaiImagesAdapter, dashscopeImagesAdapter];
+
+const ADAPTERS_BY_PROTOCOL = new Map<
+  ImageServiceProtocol,
+  ImageGenerationProtocolAdapter
+>(
+  IMAGE_GENERATION_PROTOCOL_ADAPTERS.map((adapter) => [
+    adapter.protocol,
+    adapter,
+  ]),
+);
+
+export function getImageGenerationAdapter(
+  protocol: ImageServiceProtocol,
+): ImageGenerationProtocolAdapter {
+  const adapter = ADAPTERS_BY_PROTOCOL.get(protocol);
+  if (!adapter) {
+    throw new Error(`不支持的图像生成协议：${protocol}`);
+  }
+  return adapter;
+}

--- a/src/ai/infrastructure/openai-images-adapter.test.ts
+++ b/src/ai/infrastructure/openai-images-adapter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { openaiImagesAdapter } from './openai-images-adapter';
+
+describe('openaiImagesAdapter', () => {
+  it('has correct protocol metadata', () => {
+    expect(openaiImagesAdapter.protocol).toBe('openai-images');
+    expect(openaiImagesAdapter.label).toBe('OpenAI Images API');
+    expect(openaiImagesAdapter.defaultBaseUrl).toBe(
+      'https://api.openai.com/v1',
+    );
+  });
+
+  it('buildUrl appends /images/generations to baseUrl', () => {
+    expect(openaiImagesAdapter.buildUrl('https://api.openai.com/v1')).toBe(
+      'https://api.openai.com/v1/images/generations',
+    );
+    expect(openaiImagesAdapter.buildUrl('https://custom.example/v1')).toBe(
+      'https://custom.example/v1/images/generations',
+    );
+  });
+
+  it('buildRequestBody includes required fields and optional quality/outputFormat', () => {
+    const body = openaiImagesAdapter.buildRequestBody({
+      prompt: 'a cat',
+      model: 'gpt-image-2',
+      size: '1024x1024',
+      count: 2,
+      quality: 'high',
+      outputFormat: 'webp',
+    });
+    expect(body).toEqual({
+      model: 'gpt-image-2',
+      prompt: 'a cat',
+      n: 2,
+      size: '1024x1024',
+      quality: 'high',
+      output_format: 'webp',
+    });
+  });
+
+  it('buildRequestBody omits quality and outputFormat when not provided', () => {
+    const body = openaiImagesAdapter.buildRequestBody({
+      prompt: 'a cat',
+      model: 'gpt-image-2',
+      size: '1024x1024',
+    });
+    expect(body).toEqual({
+      model: 'gpt-image-2',
+      prompt: 'a cat',
+      n: 1,
+      size: '1024x1024',
+    });
+    expect(body).not.toHaveProperty('quality');
+    expect(body).not.toHaveProperty('output_format');
+  });
+
+  it('parseResponse extracts b64_json from first data element', () => {
+    const result = openaiImagesAdapter.parseResponse({
+      data: [
+        { b64_json: 'base64data' },
+        { url: 'https://example.com/img.png' },
+      ],
+    });
+    expect(result).toEqual({ b64: 'base64data' });
+  });
+
+  it('parseResponse falls back to url when b64_json is absent', () => {
+    const result = openaiImagesAdapter.parseResponse({
+      data: [{ url: 'https://example.com/img.png' }],
+    });
+    expect(result).toEqual({ url: 'https://example.com/img.png' });
+  });
+
+  it('parseResponse returns null for empty data array', () => {
+    expect(openaiImagesAdapter.parseResponse({ data: [] })).toBeNull();
+  });
+
+  it('parseResponse returns null for non-object payload', () => {
+    expect(openaiImagesAdapter.parseResponse(null)).toBeNull();
+    expect(openaiImagesAdapter.parseResponse('string')).toBeNull();
+    expect(openaiImagesAdapter.parseResponse(42)).toBeNull();
+  });
+
+  it('parseResponse returns null when data is not an array', () => {
+    expect(openaiImagesAdapter.parseResponse({ data: 'not-array' })).toBeNull();
+  });
+});

--- a/src/ai/infrastructure/openai-images-adapter.test.ts
+++ b/src/ai/infrastructure/openai-images-adapter.test.ts
@@ -9,6 +9,7 @@ describe('openaiImagesAdapter', () => {
     expect(openaiImagesAdapter.defaultBaseUrl).toBe(
       'https://api.openai.com/v1',
     );
+    expect(openaiImagesAdapter.defaultModel).toBe('gpt-image-2');
   });
 
   it('buildUrl appends /images/generations to baseUrl', () => {

--- a/src/ai/infrastructure/openai-images-adapter.ts
+++ b/src/ai/infrastructure/openai-images-adapter.ts
@@ -1,0 +1,50 @@
+import type {
+  ImageGenerationProtocolAdapter,
+  ImageGenerationRequestInput,
+} from '../domain/image-generation-protocol';
+
+export const openaiImagesAdapter: ImageGenerationProtocolAdapter = {
+  protocol: 'openai-images',
+  label: 'OpenAI Images API',
+  description:
+    '使用 OpenAI 图片生成接口格式（/images/generations），返回 b64 或 URL。',
+  defaultBaseUrl: 'https://api.openai.com/v1',
+
+  buildUrl(baseUrl: string): string {
+    return `${baseUrl}/images/generations`;
+  },
+
+  buildRequestBody(
+    input: ImageGenerationRequestInput,
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model: input.model,
+      prompt: input.prompt,
+      n: input.count ?? 1,
+      size: input.size,
+    };
+    if (input.quality) body.quality = input.quality;
+    if (input.outputFormat) body.output_format = input.outputFormat;
+    return body;
+  },
+
+  parseResponse(payload: unknown): { url?: string; b64?: string } | null {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return null;
+    }
+    const record = payload as Record<string, unknown>;
+    if (!Array.isArray(record.data)) return null;
+    const image = record.data.find(
+      (item: unknown): item is Record<string, unknown> =>
+        Boolean(item && typeof item === 'object' && !Array.isArray(item)),
+    );
+    if (!image) return null;
+    if (typeof image.b64_json === 'string' && image.b64_json) {
+      return { b64: image.b64_json };
+    }
+    if (typeof image.url === 'string' && image.url) {
+      return { url: image.url };
+    }
+    return null;
+  },
+};

--- a/src/ai/infrastructure/openai-images-adapter.ts
+++ b/src/ai/infrastructure/openai-images-adapter.ts
@@ -1,6 +1,8 @@
+import { AI_IMAGE_GENERATION_MODEL } from '../domain/image-generation';
 import type {
   ImageGenerationProtocolAdapter,
   ImageGenerationRequestInput,
+  ImageGenerationResult,
 } from '../domain/image-generation-protocol';
 
 export const openaiImagesAdapter: ImageGenerationProtocolAdapter = {
@@ -9,6 +11,7 @@ export const openaiImagesAdapter: ImageGenerationProtocolAdapter = {
   description:
     '使用 OpenAI 图片生成接口格式（/images/generations），返回 b64 或 URL。',
   defaultBaseUrl: 'https://api.openai.com/v1',
+  defaultModel: AI_IMAGE_GENERATION_MODEL,
 
   buildUrl(baseUrl: string): string {
     return `${baseUrl}/images/generations`;
@@ -28,7 +31,7 @@ export const openaiImagesAdapter: ImageGenerationProtocolAdapter = {
     return body;
   },
 
-  parseResponse(payload: unknown): { url?: string; b64?: string } | null {
+  parseResponse(payload: unknown): ImageGenerationResult | null {
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       return null;
     }

--- a/src/features/assistant/ImageServiceSettings.tsx
+++ b/src/features/assistant/ImageServiceSettings.tsx
@@ -45,6 +45,7 @@ export function ImageServiceSettings({
   }
 
   const independent = credentialSource === 'independent';
+  const separateBaseUrl = independent || protocol === 'dashscope';
   const currentAdapter = IMAGE_GENERATION_PROTOCOL_ADAPTERS.find(
     (adapter) => adapter.protocol === protocol,
   );
@@ -97,14 +98,11 @@ export function ImageServiceSettings({
                 }
                 if (
                   !model.trim() ||
-                  model === AI_IMAGE_GENERATION_MODEL ||
-                  model === 'z-image-turbo'
+                  IMAGE_GENERATION_PROTOCOL_ADAPTERS.some(
+                    (adapter) => adapter.defaultModel === model,
+                  )
                 ) {
-                  setModel(
-                    next === 'openai-images'
-                      ? AI_IMAGE_GENERATION_MODEL
-                      : 'z-image-turbo',
-                  );
+                  setModel(nextAdapter.defaultModel);
                 }
               }
               setProtocol(next);
@@ -139,7 +137,7 @@ export function ImageServiceSettings({
           <option value="independent">独立图像服务</option>
         </select>
       </label>
-      {independent && (
+      {separateBaseUrl && (
         <>
           <label className="cm-assistant-service-field">
             <span className="cm-assistant-service-field__label">API 地址</span>
@@ -152,16 +150,21 @@ export function ImageServiceSettings({
               onChange={(event) => update(() => setBaseUrl(event.target.value))}
             />
           </label>
-          <CredentialField
-            label="API 密钥"
-            value={apiKey}
-            hasCredential={Boolean(config?.imageService.hasCredential)}
-            busy={busy}
-            placeholder="输入图像服务 API 密钥"
-            clearSavedLabel="清除已保存图像服务密钥"
-            onChange={setApiKey}
-            onClear={clearCredential}
-          />
+          {independent && (
+            <CredentialField
+              label="API 密钥"
+              value={apiKey}
+              hasCredential={Boolean(
+                config?.imageService.hasCredential &&
+                  config.imageService.protocol === protocol,
+              )}
+              busy={busy}
+              placeholder="输入图像服务 API 密钥"
+              clearSavedLabel="清除已保存图像服务密钥"
+              onChange={setApiKey}
+              onClear={clearCredential}
+            />
+          )}
         </>
       )}
       <label className="cm-assistant-service-field">
@@ -170,7 +173,7 @@ export function ImageServiceSettings({
           className="cm-assistant-form-control"
           value={model}
           placeholder={
-            currentAdapter?.defaultBaseUrl ? model : AI_IMAGE_GENERATION_MODEL
+            currentAdapter?.defaultModel ?? AI_IMAGE_GENERATION_MODEL
           }
           disabled={busy}
           spellCheck={false}
@@ -180,7 +183,9 @@ export function ImageServiceSettings({
       <p className="cm-assistant-settings-copy">
         {independent
           ? `请求使用${currentAdapter?.label ?? protocol}的生成参数和响应格式。`
-          : '沿用模型服务的 API 地址和密钥，只单独指定生图模型。'}
+          : protocol === 'dashscope'
+            ? '沿用模型服务的 API 密钥，单独使用上方百炼图像 API 地址。'
+            : '沿用模型服务的 API 地址和密钥，只单独指定生图模型。'}
       </p>
       <div className="cm-assistant-service-settings__actions">
         <UiLoader
@@ -192,7 +197,9 @@ export function ImageServiceSettings({
         <button
           type="button"
           className="cm-assistant-primary-button"
-          disabled={busy || !model.trim() || (independent && !baseUrl.trim())}
+          disabled={
+            busy || !model.trim() || (separateBaseUrl && !baseUrl.trim())
+          }
           onClick={() => {
             setBusy(true);
             setStatus(null);

--- a/src/features/assistant/ImageServiceSettings.tsx
+++ b/src/features/assistant/ImageServiceSettings.tsx
@@ -5,7 +5,9 @@ import type {
   AiServicesConfigView,
   AiServicesController,
   ImageServiceCredentialSource,
+  ImageServiceProtocol,
 } from '../../ai/domain/types';
+import { IMAGE_GENERATION_PROTOCOL_ADAPTERS } from '../../ai/infrastructure/image-generation-protocol-registry';
 import { UiLoader } from '../../components/ui/Ui';
 import { CredentialField } from './AssistantSettingsPrimitives';
 
@@ -20,6 +22,8 @@ export function ImageServiceSettings({
 }) {
   const [credentialSource, setCredentialSource] =
     useState<ImageServiceCredentialSource>('model-service');
+  const [protocol, setProtocol] =
+    useState<ImageServiceProtocol>('openai-images');
   const [baseUrl, setBaseUrl] = useState('');
   const [model, setModel] = useState(AI_IMAGE_GENERATION_MODEL);
   const [apiKey, setApiKey] = useState('');
@@ -31,6 +35,7 @@ export function ImageServiceSettings({
   useEffect(() => {
     if (!config || dirty) return;
     setCredentialSource(config.imageService.credentialSource);
+    setProtocol(config.imageService.protocol);
     setBaseUrl(config.imageService.baseUrl);
     setModel(config.imageService.model);
   }, [config, dirty]);
@@ -40,6 +45,10 @@ export function ImageServiceSettings({
   }
 
   const independent = credentialSource === 'independent';
+  const currentAdapter = IMAGE_GENERATION_PROTOCOL_ADAPTERS.find(
+    (adapter) => adapter.protocol === protocol,
+  );
+
   const update = (change: () => void) => {
     change();
     setDirty(true);
@@ -69,12 +78,49 @@ export function ImageServiceSettings({
     <div className="cm-assistant-service-settings">
       <label className="cm-assistant-service-field">
         <span className="cm-assistant-service-field__label">接口协议</span>
-        <input
+        <select
           className="cm-assistant-form-control"
-          value="OpenAI Images API"
-          readOnly
-        />
+          value={protocol}
+          disabled={busy}
+          onChange={(event) => {
+            const next = event.target.value as ImageServiceProtocol;
+            update(() => {
+              const nextAdapter = IMAGE_GENERATION_PROTOCOL_ADAPTERS.find(
+                (adapter) => adapter.protocol === next,
+              );
+              if (nextAdapter) {
+                if (
+                  !baseUrl.trim() ||
+                  baseUrl === currentAdapter?.defaultBaseUrl
+                ) {
+                  setBaseUrl(nextAdapter.defaultBaseUrl);
+                }
+                if (
+                  !model.trim() ||
+                  model === AI_IMAGE_GENERATION_MODEL ||
+                  model === 'z-image-turbo'
+                ) {
+                  setModel(
+                    next === 'openai-images'
+                      ? AI_IMAGE_GENERATION_MODEL
+                      : 'z-image-turbo',
+                  );
+                }
+              }
+              setProtocol(next);
+            });
+          }}
+        >
+          {IMAGE_GENERATION_PROTOCOL_ADAPTERS.map((adapter) => (
+            <option key={adapter.protocol} value={adapter.protocol}>
+              {adapter.label}
+            </option>
+          ))}
+        </select>
       </label>
+      <p className="cm-assistant-settings-copy">
+        {currentAdapter?.description}
+      </p>
       <label className="cm-assistant-service-field">
         <span className="cm-assistant-service-field__label">凭据来源</span>
         <select
@@ -101,7 +147,7 @@ export function ImageServiceSettings({
               className="cm-assistant-form-control"
               value={baseUrl}
               type="url"
-              placeholder="OpenAI 兼容图像服务基础地址"
+              placeholder="图像服务基础地址"
               disabled={busy}
               onChange={(event) => update(() => setBaseUrl(event.target.value))}
             />
@@ -123,7 +169,9 @@ export function ImageServiceSettings({
         <input
           className="cm-assistant-form-control"
           value={model}
-          placeholder={AI_IMAGE_GENERATION_MODEL}
+          placeholder={
+            currentAdapter?.defaultBaseUrl ? model : AI_IMAGE_GENERATION_MODEL
+          }
           disabled={busy}
           spellCheck={false}
           onChange={(event) => update(() => setModel(event.target.value))}
@@ -131,7 +179,7 @@ export function ImageServiceSettings({
       </label>
       <p className="cm-assistant-settings-copy">
         {independent
-          ? '请求固定使用 OpenAI Images API 的生成参数和响应格式。'
+          ? `请求使用${currentAdapter?.label ?? protocol}的生成参数和响应格式。`
           : '沿用模型服务的 API 地址和密钥，只单独指定生图模型。'}
       </p>
       <div className="cm-assistant-service-settings__actions">
@@ -152,7 +200,7 @@ export function ImageServiceSettings({
             void services
               .saveImageService({
                 credentialSource,
-                protocol: 'openai-images',
+                protocol,
                 baseUrl:
                   baseUrl.trim() ||
                   config?.modelService.baseUrl ||
@@ -164,7 +212,7 @@ export function ImageServiceSettings({
                 setDirty(false);
                 setApiKey('');
                 onConfigChange(next);
-                setStatus('OpenAI 兼容图像服务配置已保存。');
+                setStatus('图像服务配置已保存。');
               })
               .catch((failure) => setError(assistantUserFacingError(failure)))
               .finally(() => setBusy(false));

--- a/src/hosts/extension/ai-services-config.test.ts
+++ b/src/hosts/extension/ai-services-config.test.ts
@@ -362,6 +362,38 @@ describe('extension AI services config', () => {
     expect(result.baseUrl).toBe('https://dashscope.aliyuncs.com');
   });
 
+  it('reuses a model credential without reusing its endpoint for dashscope', () => {
+    const dashscopeConfig = structuredClone(DEFAULT_AI_SERVICES_CONFIG);
+    dashscopeConfig.modelService.baseUrl = 'https://chat.example/v1';
+    dashscopeConfig.modelService.apiKey = 'shared-key';
+    dashscopeConfig.imageService.protocol = 'dashscope';
+    dashscopeConfig.imageService.baseUrl = 'https://dashscope.aliyuncs.com';
+    const result = resolveImageServiceRuntimeConfig(dashscopeConfig);
+    expect(result).toMatchObject({
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      apiKey: 'shared-key',
+    });
+  });
+
+  it('does not carry an independent API key across image protocols', async () => {
+    const { storage } = memoryStorage();
+    await saveImageServiceConfig(storage, {
+      credentialSource: 'independent',
+      protocol: 'openai-images',
+      baseUrl: 'https://images.example/v1',
+      model: 'gpt-image-2',
+      apiKey: 'openai-key',
+    });
+    await saveImageServiceConfig(storage, {
+      credentialSource: 'independent',
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      model: 'z-image-turbo',
+    });
+    expect((await readAiServicesConfig(storage))?.imageService.apiKey).toBe('');
+  });
+
   it('aiServicesView exposes image service protocol', async () => {
     const { storage } = memoryStorage();
     await saveImageServiceConfig(storage, {

--- a/src/hosts/extension/ai-services-config.test.ts
+++ b/src/hosts/extension/ai-services-config.test.ts
@@ -13,6 +13,7 @@ import {
   clearSpeechServiceCredential,
   DEFAULT_AI_SERVICES_CONFIG,
   readAiServicesConfig,
+  resolveImageServiceRuntimeConfig,
   saveImageServiceConfig,
   saveModelServiceConfig,
   saveSpeechServiceConfig,
@@ -308,5 +309,68 @@ describe('extension AI services config', () => {
       reasoningEffort: 'high',
     });
     expect(Object.keys(values)).toEqual([AI_SERVICES_STORAGE_KEY]);
+  });
+
+  it('accepts dashscope protocol and does not force /v1 root path', () => {
+    expect(
+      normalizeImageServiceInput({
+        credentialSource: 'independent',
+        protocol: 'dashscope',
+        baseUrl: 'https://dashscope.aliyuncs.com',
+        model: 'z-image-turbo',
+      }),
+    ).toEqual({
+      credentialSource: 'independent',
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      model: 'z-image-turbo',
+    });
+  });
+
+  it('saves and reads dashscope image service config', async () => {
+    const { storage } = memoryStorage();
+    await saveImageServiceConfig(storage, {
+      credentialSource: 'independent',
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      model: 'z-image-turbo',
+      apiKey: 'ds-key',
+    });
+    const config = await readAiServicesConfig(storage);
+    expect(config?.imageService).toEqual({
+      credentialSource: 'independent',
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      model: 'z-image-turbo',
+      apiKey: 'ds-key',
+    });
+  });
+
+  it('resolveImageServiceRuntimeConfig returns protocol', () => {
+    const result = resolveImageServiceRuntimeConfig(DEFAULT_AI_SERVICES_CONFIG);
+    expect(result).toHaveProperty('protocol', 'openai-images');
+  });
+
+  it('resolveImageServiceRuntimeConfig returns dashscope protocol when configured', () => {
+    const dashscopeConfig = structuredClone(DEFAULT_AI_SERVICES_CONFIG);
+    dashscopeConfig.imageService.credentialSource = 'independent';
+    dashscopeConfig.imageService.protocol = 'dashscope';
+    dashscopeConfig.imageService.baseUrl = 'https://dashscope.aliyuncs.com';
+    dashscopeConfig.imageService.model = 'z-image-turbo';
+    const result = resolveImageServiceRuntimeConfig(dashscopeConfig);
+    expect(result.protocol).toBe('dashscope');
+    expect(result.baseUrl).toBe('https://dashscope.aliyuncs.com');
+  });
+
+  it('aiServicesView exposes image service protocol', async () => {
+    const { storage } = memoryStorage();
+    await saveImageServiceConfig(storage, {
+      credentialSource: 'independent',
+      protocol: 'dashscope',
+      baseUrl: 'https://dashscope.aliyuncs.com',
+      model: 'z-image-turbo',
+    });
+    const view = aiServicesView(await readAiServicesConfig(storage));
+    expect(view.imageService.protocol).toBe('dashscope');
   });
 });

--- a/src/hosts/extension/ai-services-config.ts
+++ b/src/hosts/extension/ai-services-config.ts
@@ -49,11 +49,13 @@ export function resolveImageServiceRuntimeConfig(config: AiServicesConfig) {
   const { imageService, modelService } = config;
   return imageService.credentialSource === 'model-service'
     ? {
+        protocol: imageService.protocol,
         baseUrl: modelService.baseUrl,
         model: imageService.model,
         apiKey: modelService.apiKey,
       }
     : {
+        protocol: imageService.protocol,
         baseUrl: imageService.baseUrl,
         model: imageService.model,
         apiKey: imageService.apiKey,
@@ -162,7 +164,7 @@ export async function saveImageServiceConfig(
   }
   const normalized = normalizeImageServiceInput(input);
   if (!normalized) {
-    throw new Error('请填写有效的 OpenAI 兼容图像服务配置。');
+    throw new Error('请填写有效的图像服务配置。');
   }
   const current = resolveAiServicesRuntimeConfig(
     await readAiServicesConfig(storage),

--- a/src/hosts/extension/ai-services-config.ts
+++ b/src/hosts/extension/ai-services-config.ts
@@ -50,7 +50,10 @@ export function resolveImageServiceRuntimeConfig(config: AiServicesConfig) {
   return imageService.credentialSource === 'model-service'
     ? {
         protocol: imageService.protocol,
-        baseUrl: modelService.baseUrl,
+        baseUrl:
+          imageService.protocol === 'openai-images'
+            ? modelService.baseUrl
+            : imageService.baseUrl,
         model: imageService.model,
         apiKey: modelService.apiKey,
       }
@@ -169,8 +172,12 @@ export async function saveImageServiceConfig(
   const current = resolveAiServicesRuntimeConfig(
     await readAiServicesConfig(storage),
   );
+  const previousApiKey =
+    normalized.protocol === current.imageService.protocol
+      ? current.imageService.apiKey
+      : '';
   const apiKey = normalizeHttpHeaderCredential(
-    normalized.apiKey || current.imageService.apiKey,
+    normalized.apiKey || previousApiKey,
     '图像服务 API 密钥',
   );
   return writeAiServicesConfig(storage, {

--- a/src/hosts/extension/daily-review-image.test.ts
+++ b/src/hosts/extension/daily-review-image.test.ts
@@ -155,7 +155,7 @@ describe('DailyReviewImageGenerator', () => {
                   },
                 ],
               },
-              usage: { width: 3840, height: 2160, image_count: 1 },
+              usage: { width: 2048, height: 1152, image_count: 1 },
               request_id: 'test-123',
             }),
             { status: 200 },
@@ -188,10 +188,14 @@ describe('DailyReviewImageGenerator', () => {
         ],
       },
       parameters: {
-        size: '3840*2160',
+        size: '2048*1152',
         prompt_extend: false,
       },
     });
-    expect(result.model).toBe('z-image-turbo');
+    expect(result).toMatchObject({
+      model: 'z-image-turbo',
+      width: 2048,
+      height: 1152,
+    });
   });
 });

--- a/src/hosts/extension/daily-review-image.test.ts
+++ b/src/hosts/extension/daily-review-image.test.ts
@@ -109,4 +109,89 @@ describe('DailyReviewImageGenerator', () => {
       buildDailyReviewImageRequest('A complete English wallpaper prompt.'),
     ).toThrow('每日回顾提示词必须使用简体中文');
   });
+
+  it('uses dashscope adapter when protocol is dashscope', async () => {
+    const dashscopeConfig: AiServicesConfig = {
+      modelService: {
+        baseUrl: 'https://api.example.com/v1',
+        model: 'deepseek-v4-flash',
+        protocol: 'responses',
+        reasoningEffort: 'high',
+        apiKey: 'model-key',
+      },
+      imageService: {
+        credentialSource: 'independent',
+        protocol: 'dashscope',
+        baseUrl: 'https://dashscope.aliyuncs.com',
+        model: 'z-image-turbo',
+        apiKey: 'dashscope-key',
+      },
+      speechService: { apiKey: '' },
+    };
+    let capturedUrl: string | undefined;
+    let requestBody: Record<string, unknown> | null = null;
+    let callIndex = 0;
+    const request = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        callIndex++;
+        if (callIndex === 1) {
+          capturedUrl = String(input);
+          requestBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return new Response(
+            JSON.stringify({
+              output: {
+                choices: [
+                  {
+                    finish_reason: 'stop',
+                    message: {
+                      role: 'assistant',
+                      content: [
+                        { image: 'https://oss.example/img.png?Expires=123' },
+                      ],
+                    },
+                  },
+                ],
+              },
+              usage: { width: 3840, height: 2160, image_count: 1 },
+              request_id: 'test-123',
+            }),
+            { status: 200 },
+          );
+        }
+        // Image download — return minimal JPEG bytes (SOI + EOI)
+        return new Response(
+          new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0xff, 0xd9]),
+          { status: 200 },
+        );
+      },
+    );
+    const generator = new DailyReviewImageGenerator(request as typeof fetch);
+
+    const result = await generator.generate(
+      dashscopeConfig,
+      '一张完整连贯的生活回顾场景。',
+    );
+    expect(capturedUrl).toBe(
+      'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
+    );
+    expect(requestBody).toEqual({
+      model: 'z-image-turbo',
+      input: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: '一张完整连贯的生活回顾场景。' }],
+          },
+        ],
+      },
+      parameters: {
+        size: '3840*2160',
+        prompt_extend: false,
+      },
+    });
+    expect(result.model).toBe('z-image-turbo');
+  });
 });

--- a/src/hosts/extension/daily-review-image.ts
+++ b/src/hosts/extension/daily-review-image.ts
@@ -262,8 +262,8 @@ export class DailyReviewImageGenerator {
       dataUrl,
       mimeType,
       byteLength,
-      width: dimensions.width,
-      height: dimensions.height,
+      width: parsed.width ?? dimensions.width,
+      height: parsed.height ?? dimensions.height,
       model,
     };
   }

--- a/src/hosts/extension/daily-review-image.ts
+++ b/src/hosts/extension/daily-review-image.ts
@@ -1,8 +1,5 @@
 import { isSecureServiceUrl } from '../../ai/domain/ai-services-schema';
-import {
-  AI_IMAGE_GENERATION_MODEL,
-  AI_IMAGE_GENERATION_PATH,
-} from '../../ai/domain/image-generation';
+import { AI_IMAGE_GENERATION_MODEL } from '../../ai/domain/image-generation';
 import type { AiServicesConfig } from '../../ai/domain/types';
 import {
   type AiServiceFetch,
@@ -10,6 +7,7 @@ import {
   readAiServiceText,
   requestAiService,
 } from '../../ai/infrastructure/ai-service-http';
+import { getImageGenerationAdapter } from '../../ai/infrastructure/image-generation-protocol-registry';
 import { dailyReviewPromptUsesChinese } from '../../new-tab/application/daily-review-wallpaper';
 import type { DailyReviewWallpaperResolution } from '../../new-tab/application/preferences';
 import { resolveImageServiceRuntimeConfig } from './ai-services-config';
@@ -196,13 +194,21 @@ export class DailyReviewImageGenerator {
       );
     }
 
+    const adapter = getImageGenerationAdapter(imageConfig.protocol);
     const response = await requestAiService(
       this.request,
       { apiKey },
-      `${baseUrl}${AI_IMAGE_GENERATION_PATH}`,
-      buildDailyReviewImageRequest(prompt, model, size),
+      adapter.buildUrl(baseUrl),
+      adapter.buildRequestBody({
+        prompt,
+        model,
+        size,
+        count: 1,
+        quality: 'high',
+        outputFormat: 'webp',
+      }),
       signal,
-      { protocol: 'openai-images' },
+      { protocol: imageConfig.protocol },
     );
     const text = await readAiServiceText(response, signal);
     if (!response.ok) {
@@ -215,25 +221,24 @@ export class DailyReviewImageGenerator {
     } catch {
       throw new Error('每日回顾图像服务返回了无效 JSON。');
     }
-    if (!record(payload) || !Array.isArray(payload.data)) {
+    const parsed = adapter.parseResponse(payload);
+    if (!parsed) {
       throw new Error('每日回顾图像服务没有返回图片。');
     }
-    const image = payload.data.find(record);
-    if (!image) throw new Error('每日回顾图像服务没有返回图片。');
 
     let dataUrl: string;
     let mimeType = DAILY_REVIEW_MIME_TYPE;
     let byteLength: number;
-    if (typeof image.b64_json === 'string' && image.b64_json) {
-      const normalized = normalizedBase64Image(image.b64_json);
+    if (parsed.b64) {
+      const normalized = normalizedBase64Image(parsed.b64);
       dataUrl = normalized.dataUrl;
       mimeType = normalized.mimeType;
       byteLength = normalized.byteLength;
-    } else if (typeof image.url === 'string' && image.url) {
-      if (!isSecureServiceUrl(image.url)) {
+    } else if (parsed.url) {
+      if (!isSecureServiceUrl(parsed.url)) {
         throw new Error('每日回顾图像服务返回了不安全的图片地址。');
       }
-      const imageResponse = await this.request(image.url, { signal });
+      const imageResponse = await this.request(parsed.url, { signal });
       if (!imageResponse.ok) {
         throw new Error(`下载每日回顾失败：HTTP ${imageResponse.status}。`);
       }

--- a/src/hosts/extension/image-card-cover.test.ts
+++ b/src/hosts/extension/image-card-cover.test.ts
@@ -172,4 +172,87 @@ describe('卡牌封面生成', () => {
     ).rejects.toThrow('不安全的图片地址');
     expect(request).toHaveBeenCalledOnce();
   });
+
+  it('uses dashscope adapter when protocol is dashscope', async () => {
+    let capturedUrl: string | undefined;
+    let requestBody: Record<string, unknown> | null = null;
+    let callIndex = 0;
+    const request = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        callIndex++;
+        if (callIndex === 1) {
+          capturedUrl = String(input);
+          requestBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return new Response(
+            JSON.stringify({
+              output: {
+                choices: [
+                  {
+                    finish_reason: 'stop',
+                    message: {
+                      role: 'assistant',
+                      content: [
+                        { image: 'https://oss.example/cover.png?Expires=456' },
+                      ],
+                    },
+                  },
+                ],
+              },
+              usage: { width: 720, height: 960, image_count: 1 },
+              request_id: 'cover-123',
+            }),
+            { status: 200 },
+          );
+        }
+        // Image download — return 500 to avoid createImageBitmap/OffscreenCanvas
+        // which are unavailable in the Node.js test environment
+        return new Response('download failed', { status: 500 });
+      },
+    );
+    const generator = new ImageCardCoverGenerator(request as typeof fetch);
+
+    await expect(
+      generator.generate(
+        {
+          modelService: {
+            baseUrl: 'https://chat.example/v1',
+            model: 'deepseek-v4-flash',
+            protocol: 'chat-completions',
+            reasoningEffort: 'high',
+            apiKey: '',
+          },
+          imageService: {
+            credentialSource: 'independent',
+            protocol: 'dashscope',
+            baseUrl: 'https://dashscope.aliyuncs.com',
+            model: 'z-image-turbo',
+            apiKey: 'ds-key',
+          },
+          speechService: { apiKey: '' },
+        },
+        'A librarian forging a browser spell into an illustrated card',
+      ),
+    ).rejects.toThrow('下载卡牌封面失败');
+    expect(capturedUrl).toBe(
+      'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
+    );
+    expect(requestBody).toMatchObject({
+      model: 'z-image-turbo',
+      input: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: expect.stringContaining('A librarian') }],
+          },
+        ],
+      },
+      parameters: {
+        size: '720*960',
+        prompt_extend: false,
+      },
+    });
+  });
 });

--- a/src/hosts/extension/image-card-cover.ts
+++ b/src/hosts/extension/image-card-cover.ts
@@ -1,8 +1,5 @@
 import { isSecureServiceUrl } from '../../ai/domain/ai-services-schema';
-import {
-  AI_IMAGE_GENERATION_MODEL,
-  AI_IMAGE_GENERATION_PATH,
-} from '../../ai/domain/image-generation';
+import { AI_IMAGE_GENERATION_MODEL } from '../../ai/domain/image-generation';
 import type { AiServicesConfig } from '../../ai/domain/types';
 import {
   type AiServiceFetch,
@@ -10,6 +7,7 @@ import {
   readAiServiceText,
   requestAiService,
 } from '../../ai/infrastructure/ai-service-http';
+import { getImageGenerationAdapter } from '../../ai/infrastructure/image-generation-protocol-registry';
 import { CARD_ART_DIRECTION_PROMPT } from '../../userscript/application/card-art-direction';
 import {
   type GeneratedUserscriptCover,
@@ -115,21 +113,26 @@ export class ImageCardCoverGenerator {
     if (!apiKey) {
       throw new Error(
         usesModelServiceCredential
-          ? 'OpenAI 兼容图像生成正在沿用模型服务，请先配置模型服务 API 密钥，或改用独立图像服务。'
-          : 'OpenAI 兼容图像服务尚未配置，请填写独立图像服务的 API 密钥。',
+          ? '图像生成正在沿用模型服务，请先配置模型服务 API 密钥，或改用独立图像服务。'
+          : '图像服务尚未配置，请填写独立图像服务的 API 密钥。',
       );
     }
 
+    const adapter = getImageGenerationAdapter(imageConfig.protocol);
     const response = await requestAiService(
       this.request,
       { apiKey },
-      `${baseUrl}${AI_IMAGE_GENERATION_PATH}`,
-      buildCardCoverRequest(
-        buildCardCoverPrompt(visualConcept, promptOptions),
+      adapter.buildUrl(baseUrl),
+      adapter.buildRequestBody({
+        prompt: buildCardCoverPrompt(visualConcept, promptOptions),
         model,
-      ),
+        size: SOURCE_SIZE,
+        count: 1,
+        quality: 'low',
+        outputFormat: 'webp',
+      }),
       signal,
-      { protocol: 'openai-images' },
+      { protocol: imageConfig.protocol },
     );
     const text = await readAiServiceText(response, signal);
     if (!response.ok) {
@@ -142,20 +145,19 @@ export class ImageCardCoverGenerator {
     } catch {
       throw new Error('图像服务返回了无效 JSON。');
     }
-    if (!record(payload) || !Array.isArray(payload.data)) {
+    const parsed = adapter.parseResponse(payload);
+    if (!parsed) {
       throw new Error('图像服务没有返回图片。');
     }
-    const image = payload.data.find(record);
-    if (!image) throw new Error('图像服务没有返回图片。');
 
     let source: Blob;
-    if (typeof image.b64_json === 'string' && image.b64_json) {
-      source = blobFromBase64(image.b64_json);
-    } else if (typeof image.url === 'string' && image.url) {
-      if (!isSecureServiceUrl(image.url)) {
+    if (parsed.b64) {
+      source = blobFromBase64(parsed.b64);
+    } else if (parsed.url) {
+      if (!isSecureServiceUrl(parsed.url)) {
         throw new Error('图像服务返回了不安全的图片地址。');
       }
-      const imageResponse = await this.request(image.url, {
+      const imageResponse = await this.request(parsed.url, {
         signal,
       });
       if (!imageResponse.ok) {


### PR DESCRIPTION
# 关于此 PR

原先插件仅支持 OpenAI 格式的生图接口，在 [这里](https://github.com/LYiHub/Card-master-browser-extension-public/blob/7c7d6948914b586b0d45eb28fe9a8a08380fa9db/src/ai/domain/image-generation.ts#L2) 写死了接口的调用路径，然而阿里云百炼的文生图接口并不与 OpenAI 格式兼容。

在 [这里](https://github.com/LYiHub/Card-master-browser-extension-public/blob/7c7d6948914b586b0d45eb28fe9a8a08380fa9db/src/features/assistant/ImageServiceSettings.tsx#L72-L76) 有一个只读的输入框，在本 PR 里改为了下拉框，并把生图 API 的调用逻辑抽象了出来以便后续再拓展。

此外，为了保证 UI 提示与接口类型相应，修改了部分包含 “OpenAI” 字样的表述。

# BTW

1. 该项目在 Windows 系统上由于 Git 默认 AutoCRLF 的行为不便于测试与修改，本 PR **连带提交了** `.gitattributes` 文件，统一行尾为 LF
2. README 中提到 Firefox 只能 _临时载入附加组件_ ，根据 [Mozilla Firefox 文档](https://support.mozilla.org/zh-CN/kb/add-ons-signing-firefox#w_ru-xu-shi-yong-wei-qian-ming-fu-jia-zu-jian-you-na-xie-xuan-ze-gao-ji-yong-hu) ，Firefox [延长支持版 (ESR)](https://www.mozilla.org/firefox/organizations/)、Firefox [开发者版](https://www.mozilla.org/firefox/developer/) 与 [每夜版](https://nightly.mozilla.org/) 可以禁用签名检查，**本 PR 未做修改**。