### PR TITLE
fix(input): preserve editable keys in closed shadow roots

### DIFF
--- a/src/input/coordinator.ts
+++ b/src/input/coordinator.ts
@@ -22,6 +22,19 @@ export const INPUT_SCOPE_PRIORITY = {
   testCapture: 2_000,
 } as const;
 
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+]);
+
 export type InputScope = {
   id: string;
   priority: number;
@@ -46,6 +59,20 @@ function consumeKeyboardEvent(event: KeyboardEvent) {
   event.preventDefault();
   event.stopPropagation();
   event.stopImmediatePropagation();
+}
+
+function focusedEditableElement(root: Document | ShadowRoot) {
+  const active = root.activeElement;
+  if (
+    active instanceof HTMLTextAreaElement ||
+    active instanceof HTMLSelectElement
+  ) {
+    return true;
+  }
+  if (active instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has(active.type);
+  }
+  return active instanceof HTMLElement && active.isContentEditable;
 }
 
 export class EscapeLayerStack {
@@ -254,6 +281,10 @@ export class InputCoordinator {
     if (this.processedKeyboardEvents.has(event)) return;
     this.processedKeyboardEvents.add(event);
     this.setModality('keyboard');
+    // A closed Shadow DOM retargets its keyboard events to the host before
+    // they reach the page window.  Check every registered root's active
+    // element so IME confirmation, Enter, and editing keys stay in fields.
+    if ([...this.observedRoots.keys()].some(focusedEditableElement)) return;
     if (this.escapeLayers.handle(event)) return;
     const intent = keyboardIntent(event);
     if (!intent) return;


### PR DESCRIPTION
# PR: 修复封闭 Shadow DOM 设置框中的键盘输入

## 问题

在 Chromium 的网页牌阵中打开「时光飞龙 → 设置」后，`速度法印` 是一个多行文本框。但使用中文输入法或按 Enter 编辑时，键盘事件会被卡牌的全局输入协调器接管：输入法候选无法确认，Enter 也不能换行；通过粘贴仍能修改内容。

这个问题只在设置 UI 位于封闭 Shadow DOM 中时出现。事件到达页面级 `window` 的捕获监听器前会被重定向为 Shadow host，因此原有的 `keyboardIntent()` 无法从事件路径识别实际的 textarea，并把编辑按键当成牌阵导航或确认操作处理。

## 修复

- 在 `InputCoordinator` 中检查每个已注册根节点的 `activeElement`。
- 当焦点位于可编辑的 input、textarea、select 或 contenteditable 元素时，直接让键盘事件交由浏览器和输入法处理。
- 该检查发生在 Escape 层和卡牌快捷键路由之前，因此 IME 确认、Enter、方向键和普通输入不会被全局卡牌控制抢走。

这也覆盖了其它通过封闭 Shadow DOM 挂载的卡牌设置界面，不只限于媒体倍速设置。

## 验证

- 在 Chrome 中复现并验证：打开 `时光飞龙 → 设置`，`速度法印` 文本框能够获得编辑焦点，设置内容可以修改。
- `pnpm check`
  - Biome 检查通过
  - TypeScript 类型检查通过
  - 279 个测试文件、1481 项测试全部通过
